### PR TITLE
chore: remove dependency on @backstage/core-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@backstage/catalog-model": "^0.5.0",
     "@backstage/core": "^0.4.0",
-    "@backstage/core-api": "^0.2.1",
     "@backstage/plugin-catalog": "^0.2.1",
     "@backstage/theme": "^0.2.0",
     "@material-ui/core": "^4.9.10",


### PR DESCRIPTION
This package is not supposed to be directly depended on; its vital parts are exported by `@backstage/core` which is the intended public import.